### PR TITLE
fix: make preferences type enum

### DIFF
--- a/app/libs/realm/schemas/preferences.ts
+++ b/app/libs/realm/schemas/preferences.ts
@@ -1,17 +1,23 @@
 import Realm, { ObjectSchema } from "realm";
 
 type GenerateProps = {
-  is_chatter: boolean;
-  is_pet_friendly: boolean;
-  is_smoking_allowed: boolean;
-  plays_music: boolean;
+  is_chatter: PreferencesValues;
+  is_pet_friendly: PreferencesValues;
+  is_smoking_allowed: PreferencesValues;
+  plays_music: PreferencesValues;
 };
 
+enum PreferencesValues {
+  maybe,
+  no,
+  yes,
+}
+
 export class Preferences extends Realm.Object {
-  is_chatter!: boolean;
-  is_pet_friendly!: boolean;
-  is_smoking_allowed!: boolean;
-  plays_music!: boolean;
+  is_chatter!: PreferencesValues;
+  is_pet_friendly!: PreferencesValues;
+  is_smoking_allowed!: PreferencesValues;
+  plays_music!: PreferencesValues;
 
   static schema: ObjectSchema = {
     name: "Preferences",


### PR DESCRIPTION
Preferences values were booleans, but we need more options, so now we have ["yes", "no", "maybe"] as options